### PR TITLE
properly support redcap versions that contain double digits

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -9,7 +9,7 @@ class ExternalModule extends AbstractExternalModule {
 
     function redcap_every_page_top($project_id) {
         $url = $_SERVER['REQUEST_URI'];
-        $is_on_project_home = preg_match("/\/redcap_v\d\.\d\.\d\/index\.php\?pid=\d+\z/", $url);
+        $is_on_project_home = preg_match("/\/redcap_v\d+\.\d+\.\d+\/index\.php\?pid=\d+\z/", $url);
         $is_on_project_setup = preg_match("/.*ProjectSetup.*/", $url);
 
         if ( $is_on_project_home || $is_on_project_setup) {


### PR DESCRIPTION
Correct error where banner was not appearing on a project's homepage due to it being v 8.**11**.2