### PR TITLE
add option to display on all pages of a project

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -12,7 +12,7 @@ class ExternalModule extends AbstractExternalModule {
         $is_on_project_home = preg_match("/\/redcap_v\d+\.\d+\.\d+\/index\.php\?pid=\d+\z/", $url);
         $is_on_project_setup = preg_match("/.*ProjectSetup.*/", $url);
 
-        if ( $is_on_project_home || $is_on_project_setup) {
+        if ( ($is_on_project_home || $is_on_project_setup) || $this->getSystemSetting('display_everywhere')) {
             $sql_response = $this->queryInvoices();
             if ( !$sql_response & $this->getSystemSetting('query_result_required') ) {
                 return false;

--- a/config.json
+++ b/config.json
@@ -48,6 +48,11 @@
             "name": "Require a non-empty query result",
             "key": "query_result_required",
             "type": "checkbox"
+        },
+        {
+            "name": "Display on all pages",
+            "key": "display_everywhere",
+            "type": "checkbox"
         }
     ],
     "compatibility": {

--- a/js/banner_inject.js
+++ b/js/banner_inject.js
@@ -1,3 +1,3 @@
 $(document).ready(function() {
-    $("#sub-nav").before(`<div id='project-banner'> ${banner_text}</div>`);
+    $("#subheader").after(`<div id='project-banner'> ${banner_text}</div>`);
 });

--- a/js/banner_inject.js
+++ b/js/banner_inject.js
@@ -1,3 +1,3 @@
 $(document).ready(function() {
-    $("#sub-nav").before(`<div id='project-banner'> ${data_driven_project_banner_text}</div>`);
+    $("#subheader").before(`<div id='project-banner'> ${data_driven_project_banner_text}</div>`);
 });


### PR DESCRIPTION
Addresses issue #8 

Displays banner on all pages within a project (but not survey pages). Requiring a non-empty query result will still prevent the banner from displaying in the result of an empty query.

Causes a a graphical error when editing a record, partially obscuring some text:
![image](https://user-images.githubusercontent.com/20332546/67411966-73e31800-f58c-11e9-8222-090044ab7d2f.png)
