### PR TITLE
Add support for multi row data responses, surrounding rich text fields

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -50,32 +50,38 @@ class ExternalModule extends AbstractExternalModule {
             $banner_text = "This is the default project banner. Change this in the system level module configuration for the Data Driven Project Banner Module.</br>";
         }
 
+        $banner_output = $this->getSystemSetting('banner_text_top');
         if ($sql_response) {
-            $banner_text = $this->replaceSmartVariables($banner_text, $sql_response);
+            $banner_output .= $this->replaceSmartVariables($banner_text, $sql_response);
         }
+        $banner_output .= $this->getSystemSetting('banner_text_bottom');
 
-        $banner_text = json_encode($banner_text);
+        $banner_text = json_encode($banner_output);
         echo "<script type='text/javascript'>var data_driven_project_banner_text = $banner_text;</script>";
     }
 
 
     function replaceSmartVariables($input_text, $sql_response) {
-        // "Data piping" recreation
-        $smart_variables = (
-            array_map(
-                function($x) { return "[$x]"; },
-                array_keys($sql_response[0])
-            )
-        );
+        $replaced_vals = "";
+        foreach ($sql_response as $row) {
+            // "Data piping" recreation
+            $smart_variables = (
+                array_map(
+                    function ($x) { return "[$x]"; },
+                    array_keys($row)
+                )
+            );
 
-        $smart_variables = array_combine($smart_variables, $sql_response[0]);
-        $smart_variables["[project_title]"] = REDCap::getProjectTitle();
+            $smart_variables = array_combine($smart_variables, $row);
+            $smart_variables["[project_title]"] = REDCap::getProjectTitle();
 
-        return str_replace(
-            array_keys($smart_variables),
-            array_values($smart_variables),
-            $input_text
-        );
+            $replaced_vals .= str_replace(
+                array_keys($smart_variables),
+                array_values($smart_variables),
+                $input_text
+            );
+        }
+        return $replaced_vals;
     }
 
 

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -106,7 +106,11 @@ class ExternalModule extends AbstractExternalModule {
 
 
     function queryData() {
-        return $this->performPrebuiltQuery($this->getSystemSetting('data_sql'));
+        $data_sql = $this->getSystemSetting('data_sql');
+        if ($data_sql == "custom") {
+            $data_sql = $this->getSystemSetting('custom_data_sql');
+        }
+        return $this->performPrebuiltQuery($data_sql);
     }
 
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A REDCap Module designed to display a banner at the top of select project pages.
 - REDCap >= 8.0.3
 
 ## Easy Installation
-- Obtain this module from the Consortium [REDCap Repo] (https://redcap.vanderbilt.edu/consortium/modules/index.php) from the REDCap Control Center.
+- Obtain this module from the Consortium [REDCap Repo](https://redcap.vanderbilt.edu/consortium/modules/index.php) from the REDCap Control Center.
 
 ## Manual Installation
 - Clone this repo into `<redcap-root>/modules/data_driven_project_banner_v0.0.0`.
@@ -17,6 +17,10 @@ A REDCap Module designed to display a banner at the top of select project pages.
 ## Global Configuration
 
 Typically, this module should be enabled on all projects after it has been configured.  All configuration options are at the system-level.
+
+### Multi Row Response
+
+Check this option if you expect your query will return multiple rows, doing so will reveal 2 additional fields: **Banner Top Text** and **Banner Bottom Text**. These fields will appear before and after the **Banner Text**, respectively. These fields do _not_ support data piping.
 
 ### Banner Text
 
@@ -27,7 +31,9 @@ This is the default project banner. Change this in the system level
 module configuration for the Data Driven Project Banner module.
 ```
 
-The banner text field also supports data piping akin to REDCap Smart Variables, (i.e. `[project_id]` will return the value stored for project id). That said, this module uses its _own_ set of replacement fields. The variables available for replacement are the column names in the response to the SQL query specified in the _Prebuilt SQL_ configuration option. No other values are available to be piped.
+The banner text field also supports data piping akin to REDCap Smart Variables, (i.e. `[project_id]` will return the value stored for project id). That said, this module uses its _own_ set of replacement fields. The variables available for replacement are the column names in the response to the SQL query specified in the [**Data to display**](#Data-to-display) configuration option. No other values are available to be piped.
+
+**Note:** This block will be repeated for _every row returned by the query_. If your **Data to display** query is expected to return multiple rows, use the fields provided by **Multi Row Response**
 
 ### Criteria for display
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The banner text field also supports data piping akin to REDCap Smart Variables, 
 
 Select an optional SQL query from the list provided. The recommended query is _REDCap projects table_ which runs the query `SELECT * FROM redcap_projects WHERE project_id = [project_id]` where [project_id] is the Project ID for the current project.
 
-Advanced users may edit the `config.json` file to add their own SQL queries. These queries should be project-centric and return only one row. Any reference to [project_id] in these queries will be replaced with the current Project ID. That is the only substitution made to the query string.
+Much like Criteria for display, advanced users may add their own SQL queries by selecting the "custom query option". These queries should be project-centric. Any reference to [project_id] in these queries will be replaced with the current Project ID.
 
 ### Data piping fields
 

--- a/config.json
+++ b/config.json
@@ -25,9 +25,42 @@
     ],
     "system-settings": [
         {
+            "name": "Multi Row Response",
+            "key": "multi_row_response",
+            "type": "checkbox"
+        },
+        {
+            "name": "Banner Top Text",
+            "key": "banner_text_top",
+            "type": "rich-text",
+            "branchingLogic": {
+                "conditions":
+                [
+                    {
+                        "field": "multi_row_response",
+                        "value": true
+                    }
+                ]
+            }
+        },
+        {
             "name": "Banner Text",
             "key": "banner_text",
             "type": "rich-text"
+        },
+        {
+            "name": "Banner Bottom Text",
+            "key": "banner_text_bottom",
+            "type": "rich-text",
+            "branchingLogic": {
+                "conditions":
+                [
+                    {
+                        "field": "multi_row_response",
+                        "value": true
+                    }
+                ]
+            }
         },
         {
             "name": "Banner Background Color",

--- a/config.json
+++ b/config.json
@@ -117,8 +117,26 @@
                 {
                     "name": "UF: projects for which unpaid invoices were sent over 340 days ago",
                     "value": "SELECT *, concat(\"https://redcap.ctsi.ufl.edu/invoices/invoice-\", invoice_id, \".pdf\") as invoice_url FROM uf_annual_project_billing_invoices LEFT JOIN redcap_projects USING (project_id) WHERE project_id = [project_id] AND invoice_status = 'sent' AND datediff(now(), invoice_created_date) > 340;"
+                },
+                {
+                    "name": "Custom",
+                    "value": "custom"
                 }
             ]
+        },
+        {
+            "name": "Custom SQL for data",
+            "key": "custom_data_sql",
+            "type": "text",
+            "branchingLogic": {
+                "conditions":
+                [
+                    {
+                        "field": "data_sql",
+                        "value": "custom"
+                    }
+                ]
+            }
         },
         {
             "name": "Display on all pages",


### PR DESCRIPTION
Closes #16 

Here's a snippet of SQL for a decent test query (which you still have to add to the `config.json`'s `data_sql` section because I have poor security standards...
```json
{
                    "name": "Respondent completions",
                    "value": "SELECT record, ROUND(COUNT(field_name)*100 / 8) as 'row_count' FROM redcap_data WHERE project_id = [project_id] GROUP BY record"
                 }
```
Here's the result on a tiny project.
![image](https://user-images.githubusercontent.com/20332546/121057732-98a1f880-c78d-11eb-91a7-4e06a511ac6c.png)

Please scrutinize my documentation, recreating the above image should only require the documentation and knowledge of the rich text editor field.