### PR TITLE
Ready module for 2.0.0 release

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -23,14 +23,19 @@ class ExternalModule extends AbstractExternalModule {
                 case "require_result":
                     // check if the criteria returns anything
                     if (!$sql_response) return;
-                case "always":
-                    $this->displayBanner($sql_response);
-                    break;
                 default:
+                    // always display
                     $this->displayBanner($sql_response);
                     break;
             }
         }
+    }
+
+
+    function redcap_module_configure_button_display($project_id) {
+        $this->setJsSettings(array('modulePrefix' => $this->PREFIX));
+        $this->includeJs('js/config_menu.js');
+        return true;
     }
 
 
@@ -89,6 +94,7 @@ class ExternalModule extends AbstractExternalModule {
         if (!$prebuilt_sql) {
             return;
         }
+        $prebuilt_sql = htmlspecialchars_decode($prebuilt_sql);
 
         $sql = str_replace("[project_id]", PROJECT_ID, $prebuilt_sql);
 
@@ -101,14 +107,15 @@ class ExternalModule extends AbstractExternalModule {
     }
 
     function queryCriteria() {
-        return $this->performPrebuiltQuery($this->getSystemSetting('custom_criteria_sql'));
+        $sql = "SELECT " . $this->getSystemSetting('custom_criteria_sql');
+        return $this->performPrebuiltQuery($sql);
     }
 
 
     function queryData() {
         $data_sql = $this->getSystemSetting('data_sql');
         if ($data_sql == "custom") {
-            $data_sql = $this->getSystemSetting('custom_data_sql');
+            $data_sql = "SELECT " . $this->getSystemSetting('custom_data_sql');
         }
         return $this->performPrebuiltQuery($data_sql);
     }
@@ -124,4 +131,7 @@ class ExternalModule extends AbstractExternalModule {
     }
 
 
+    protected function setJsSettings($settings) {
+        echo '<script>DDPB = ' . json_encode($settings) . ';</script>';
+    }
 }

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Much like **Criteria for display**, advanced users may add their own SQL queries
 
 ### Data piping fields
 
-If you use the _REDCap projects table_ query, there are over 110 possible column names to choose from when data piping. These columns are probably the most interesting for data piping:
+If you use the _REDCap projects table_ query in *Data to display*, there are over 110 possible column names to choose from when data piping. These columns are probably the most interesting for data piping:
 
 ```
 project_id
@@ -71,25 +71,4 @@ project_pi_pub_exclude
 project_pub_matching_institution
 project_irb_number
 project_grant_number
-```
-
-### Site-specific queries
-
-If you are using the query _UF: projects for which unpaid invoices were sent over 340 days ago_, it adds these fields to those listed above, but this query is dependent on tables available in the UF CTSI REDCap instance.
-
-```
-invoice_url
-invoice_id
-invoice_status
-invoice_created_date
-creation_time
-saved_attribute_count
-record_count
-uploaded_file_count
-total_file_storage_in_mb
-owner_username
-owner_firstname
-owner_lastname
-owner_email
-project_user_email_addresses
 ```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 A REDCap Module designed to display a banner at the top of select project pages. Supports the data piping of query results into the banner text.
 
+Please see the [CHANGELOG](CHANGELOG.md) to learn about changes and bugfixes. Version 2.0.0 introduces **breaking** changes.
+
 ## Prerequisites
 - REDCap >= 8.0.3
 
@@ -41,14 +43,14 @@ The banner text field also supports data piping akin to REDCap Smart Variables, 
 - **Always display**: Always display the banner. Note that if the SQL query in [**Data to display**](#Data-to-display) fails, the banner may still be displayed, but without the intended data piping. If a query result is _required_ to display the banner, select _Require a non-empty query result_.
 - **Require a non-empty query result**: Display the banner _only_ if the query from [**Data to display**](#Data-to-display) returns results. Useful for banners utilizing data piping fields.
 - **Custom query**: This advanced option allows you to create your own query in a new field titled **Custom SQL for criteria**; the banner will only be displayed if the result of your query is not empty.
-  - **Custom SQL for criteria**: This text field spawns when **Custom query** is selected, use this field to create your SQL statement. A simple example may be `SELECT * FROM redcap_data WHERE project_id = [project_id]`, which will cause the banner to only appear on projects which have data.
+  - **Custom SQL for criteria**: This text field spawns when **Custom query** is selected, use this field to create your SQL statement. The `SELECT` keyword is automatically prepended to queries for you as your queries should all be `SELECT` statements. A simple example may be `* FROM redcap_data WHERE project_id = [project_id]`, which will cause the banner to only appear on projects which have data.
     - Any reference to [project_id] in these queries will be replaced with the current Project ID. That is the only substitution made to the query string.
 
 ### Data to display
 
 Select an optional SQL query from the list provided. The recommended query is _REDCap projects table_ which runs the query `SELECT * FROM redcap_projects WHERE project_id = [project_id]` where [project_id] is the Project ID for the current project.
 
-Much like Criteria for display, advanced users may add their own SQL queries by selecting the "custom query option". These queries should be project-centric. Any reference to [project_id] in these queries will be replaced with the current Project ID.
+Much like **Criteria for display**, advanced users may add their own SQL queries by selecting the "custom query option". These queries should be project-centric. Any reference to [project_id] in these queries will be replaced with the current Project ID.
 
 ### Data piping fields
 

--- a/config.json
+++ b/config.json
@@ -9,18 +9,8 @@
     ],
     "authors": [
         {
-            "name": "Kyle Chesney",
-            "email": "kyle.chesney@ufl.edu",
-            "institution": "University of Florida - CTSI"
-        },
-        {
-            "name": "Taryn Stoffs",
-            "email": "tls@ufl.edu",
-            "institution": "University of Florida - CTSI"
-        },
-        {
-            "name": "Philip Chase",
-            "email": "pbc@ufl.edu",
+            "name": "University of Florida CTS-IT",
+            "email": "CTSIT-REDCAP-MODULE-SUPPO@LISTS.UFL.EDU",
             "institution": "University of Florida - CTSI"
         }
     ],

--- a/config.json
+++ b/config.json
@@ -4,7 +4,8 @@
     "namespace": "ProjectBanner\\ExternalModule",
     "documentation": "README.md",
     "permissions": [
-        "redcap_every_page_top"
+        "redcap_every_page_top",
+        "redcap_module_configure_button_display"
     ],
     "authors": [
         {
@@ -94,7 +95,7 @@
         {
             "name": "Custom SQL for criteria",
             "key": "custom_criteria_sql",
-            "type": "text",
+            "type": "textarea",
             "branchingLogic": {
                 "conditions":
                 [
@@ -127,7 +128,7 @@
         {
             "name": "Custom SQL for data",
             "key": "custom_data_sql",
-            "type": "text",
+            "type": "textarea",
             "branchingLogic": {
                 "conditions":
                 [

--- a/config.json
+++ b/config.json
@@ -106,10 +106,6 @@
                     "value": "SELECT * FROM redcap_projects WHERE project_id = [project_id]"
                 },
                 {
-                    "name": "UF: projects for which unpaid invoices were sent over 340 days ago",
-                    "value": "SELECT *, concat(\"https://redcap.ctsi.ufl.edu/invoices/invoice-\", invoice_id, \".pdf\") as invoice_url FROM uf_annual_project_billing_invoices LEFT JOIN redcap_projects USING (project_id) WHERE project_id = [project_id] AND invoice_status = 'sent' AND datediff(now(), invoice_created_date) > 340;"
-                },
-                {
                     "name": "Custom",
                     "value": "custom"
                 }

--- a/js/config_menu.js
+++ b/js/config_menu.js
@@ -1,0 +1,25 @@
+$(document).ready(function() {
+    var $modal = $('#external-modules-configure-modal');
+
+    ExternalModules.Settings.prototype.resetConfigInstancesOld = ExternalModules.Settings.prototype.resetConfigInstances;
+    ExternalModules.Settings.prototype.resetConfigInstances = function() {
+        ExternalModules.Settings.prototype.resetConfigInstancesOld();
+
+        // Making sure we are overriding this modules's modal only.
+        if ($modal.data('module') !== DDPB.modulePrefix) {
+            return;
+        }
+
+        // Add "SELECT" prefix to custom SQL query fields
+        $('[name^="custom_"][name$="_sql"]').each(function() {
+            console.log(this);
+            if ($(this).hasClass('select-prefix-set')) {
+                return;
+            }
+
+            $(this).parent().prepend('<span>SELECT</span>');
+            $(this).addClass('select-prefix-set');
+            $(this).attr('placeholder', "* FROM redcap_projects WHERE project_id = [project_id];");
+        });
+    }
+});


### PR DESCRIPTION
This PR readies the module for a 2.0.0 release.

Like REDCap Webservices, custom SQL queries are now auto-prepended with `SELECT` in the UI and in the backend before processing. (Rob's Simple Admin was not doing as much as we thought, it was effectively just checking that queries started with "select"). I've mentioned this and the presence of breaking changes in the README (directing users to the `CHANGELOG`, the root of the breakage is the removal of the `prebuilt_sql` config field.

I wonder if I should remove the 2 predefined "Data to display" queries. They seem pointless in the presence of a free response field; we can preserve our queries elsewhere.