### PR TITLE
Update config_menu.js to avoid clash with other modules overloading resetConfigInstances

### DIFF
--- a/js/config_menu.js
+++ b/js/config_menu.js
@@ -1,24 +1,31 @@
 $(document).ready(function() {
     var $modal = $('#external-modules-configure-modal');
 
-    ExternalModules.Settings.prototype.resetConfigInstancesOld = ExternalModules.Settings.prototype.resetConfigInstances;
-    ExternalModules.Settings.prototype.resetConfigInstances = function() {
-        ExternalModules.Settings.prototype.resetConfigInstancesOld();
-
-        // Making sure we are overriding this modules's modal only.
-        if ($modal.data('module') !== DDPB.modulePrefix) {
-            return;
-        }
-
-        // Add "SELECT" prefix to custom SQL query fields
-        $('[name^="custom_"][name$="_sql"]').each(function() {
-            if ($(this).hasClass('select-prefix-set')) {
-                return;
-            }
-
-            $(this).parent().prepend('<span>SELECT</span>');
-            $(this).addClass('select-prefix-set');
-            $(this).attr('placeholder', "* FROM redcap_projects WHERE project_id = [project_id];");
-        });
+    // check if other modules have set this to avoid infinite redefinition loop
+    if (typeof ExternalModules.Settings.prototype.resetConfigInstancesOld === 'undefined') {
+        ExternalModules.Settings.prototype.resetConfigInstancesOld = ExternalModules.Settings.prototype.resetConfigInstances;
     }
+
+    // fire on clicking "configure" for any module
+    $modal.on('show.bs.modal', function() {
+        // Making sure we are overriding this modules's modal only.
+        if ($(this).data('module') !== DDPB.modulePrefix) { return; }
+
+        ExternalModules.Settings.prototype.resetConfigInstances = function() {
+            ExternalModules.Settings.prototype.resetConfigInstancesOld();
+
+            // Check that resetConfigInstances is not acting on a different module
+            if ($modal.data('module') !== DDPB.modulePrefix) { return; }
+
+            // Add "SELECT" prefix to custom SQL query fields
+            $('[name^="custom_"][name$="_sql"]').each(function() {
+                // prevent duplicate prepend, necessary if config menu is closed and reopened for this module
+                if ($(this).hasClass('ddpb-select-prefix-set')) { return; }
+
+                $(this).parent().prepend('<span>SELECT</span>');
+                $(this).addClass('ddpb-select-prefix-set');
+                $(this).attr('placeholder', "* FROM redcap_projects WHERE project_id = [project_id];");
+            });
+        }
+    });
 });


### PR DESCRIPTION
Addresses a bug that occurs if any other module is defining `ExternalModules.Settings.prototype.resetConfigInstancesOld` without checking if it was already defined with`typeof ExternalModules.Settings.prototype.resetConfigInstancesOld === 'undefined'`. This prevents an infinite loop from occurring.

I ~will make~ have made a sister PR to REDCap Web Services, it looks like the only other module susceptible to this.

___
## Testing
1. Enable this module and REDCap Web Services (RCWS)
1. Navigate to the system level config menu and open your browser console
1. Open the module configuration for either this module or RCWS
1. Observe strange errors in console